### PR TITLE
Add custom DefaultTraceListener for .NET Standard 1.1

### DIFF
--- a/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.projitems
+++ b/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.projitems
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>3ff67f13-c58e-4511-af51-8d02aa779112</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>RockLib.Diagnostics.ConfigTests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\CustomTraceListener.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\SettingsTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.projitems
+++ b/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.projitems
@@ -12,9 +12,4 @@
     <Compile Include="$(MSBuildThisFileDirectory)Tracing\CustomTraceListener.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tracing\SettingsTests.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 </Project>

--- a/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.shproj
+++ b/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>7197572b-9caa-4f88-bfdd-c616bcdf4c5a</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="RockLib.Diagnostics.ConfigTests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/RockLib.Diagnostics.ConfigTests/Tracing/SettingsTests.cs
+++ b/RockLib.Diagnostics.ConfigTests/Tracing/SettingsTests.cs
@@ -2,6 +2,9 @@ using FluentAssertions;
 using RockLib.Diagnostics;
 using System.Diagnostics;
 using Xunit;
+#if NETCOREAPP1_1
+using DefaultTraceListener = RockLib.Diagnostics.DefaultTraceListener;
+#endif
 
 public partial class TheTracing
 {

--- a/RockLib.Diagnostics.ConfigTests/net462/RockLib.Diagnostics.ConfigTests.net462.csproj
+++ b/RockLib.Diagnostics.ConfigTests/net462/RockLib.Diagnostics.ConfigTests.net462.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net462</TargetFramework>
-    <AssemblyName>RockLib.Diagnostics.ConfigTests</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -15,6 +14,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <Import Project="..\RockLib.Diagnostics.ConfigTests.projitems" Label="Shared" />

--- a/RockLib.Diagnostics.ConfigTests/net462/RockLib.Diagnostics.ConfigTests.net462.csproj
+++ b/RockLib.Diagnostics.ConfigTests/net462/RockLib.Diagnostics.ConfigTests.net462.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <TargetFramework>net462</TargetFramework>
+    <AssemblyName>RockLib.Diagnostics.ConfigTests</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -14,7 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+    <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
   </ItemGroup>
+
+  <Import Project="..\RockLib.Diagnostics.ConfigTests.projitems" Label="Shared" />
 
 </Project>

--- a/RockLib.Diagnostics.ConfigTests/net462/appsettings.json
+++ b/RockLib.Diagnostics.ConfigTests/net462/appsettings.json
@@ -1,0 +1,64 @@
+﻿{
+    "rocklib.diagnostics": {
+        "trace": {
+            "autoFlush": true,
+            "indentSize": 2,
+            "useGlobalLock": false,
+            "listeners": [
+                {
+                    "name": "test_listener1",
+                    "logFileName": "test_listener1.log"
+                },
+                {
+                    "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.net462",
+                    "value": {
+                        "name": "test_listener2",
+                        "foo": "bar"
+                    }
+                }
+            ]
+        },
+        "sources": [
+            {
+                "name": "test_source1",
+                "switch": {
+                    "name": "test_source1_switch",
+                    "level": "All"
+                },
+                "listeners": [
+                    {
+                        "name": "test_listener3",
+                        "logFileName": "test_listener3.log"
+                    },
+                    {
+                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.net462",
+                        "value": {
+                            "name": "test_listener4",
+                            "foo": "baz"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "test_source2",
+                "switch": {
+                    "name": "test_source2_switch",
+                    "level": "Warning"
+                },
+                "listeners": [
+                    {
+                        "name": "test_listener5",
+                        "LogFileName": "test_listener5.log"
+                    },
+                    {
+                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.net462",
+                        "value": {
+                            "name": "test_listener6",
+                            "foo": "qux"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/RockLib.Diagnostics.ConfigTests/netcoreapp1.1/RockLib.Diagnostics.ConfigTests.netcoreapp1.1.csproj
+++ b/RockLib.Diagnostics.ConfigTests/netcoreapp1.1/RockLib.Diagnostics.ConfigTests.netcoreapp1.1.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <AssemblyName>RockLib.Diagnostics.ConfigTests</AssemblyName>
     <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DefineConstants>NETCOREAPP1_1</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,13 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+    <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+  <Import Project="..\RockLib.Diagnostics.ConfigTests.projitems" Label="Shared" />
 
 </Project>

--- a/RockLib.Diagnostics.ConfigTests/netcoreapp1.1/RockLib.Diagnostics.ConfigTests.netcoreapp1.1.csproj
+++ b/RockLib.Diagnostics.ConfigTests/netcoreapp1.1/RockLib.Diagnostics.ConfigTests.netcoreapp1.1.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
-    <AssemblyName>RockLib.Diagnostics.ConfigTests</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -19,6 +18,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <Import Project="..\RockLib.Diagnostics.ConfigTests.projitems" Label="Shared" />

--- a/RockLib.Diagnostics.ConfigTests/netcoreapp1.1/appsettings.json
+++ b/RockLib.Diagnostics.ConfigTests/netcoreapp1.1/appsettings.json
@@ -1,0 +1,64 @@
+﻿{
+    "rocklib.diagnostics": {
+        "trace": {
+            "autoFlush": true,
+            "indentSize": 2,
+            "useGlobalLock": false,
+            "listeners": [
+                {
+                    "name": "test_listener1",
+                    "logFileName": "test_listener1.log"
+                },
+                {
+                    "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.netcoreapp1.1",
+                    "value": {
+                        "name": "test_listener2",
+                        "foo": "bar"
+                    }
+                }
+            ]
+        },
+        "sources": [
+            {
+                "name": "test_source1",
+                "switch": {
+                    "name": "test_source1_switch",
+                    "level": "All"
+                },
+                "listeners": [
+                    {
+                        "name": "test_listener3",
+                        "logFileName": "test_listener3.log"
+                    },
+                    {
+                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.netcoreapp1.1",
+                        "value": {
+                            "name": "test_listener4",
+                            "foo": "baz"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "test_source2",
+                "switch": {
+                    "name": "test_source2_switch",
+                    "level": "Warning"
+                },
+                "listeners": [
+                    {
+                        "name": "test_listener5",
+                        "LogFileName": "test_listener5.log"
+                    },
+                    {
+                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.netcoreapp1.1",
+                        "value": {
+                            "name": "test_listener6",
+                            "foo": "qux"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/RockLib.Diagnostics.ConfigTests/netcoreapp2.0/RockLib.Diagnostics.ConfigTests.netcoreapp2.0.csproj
+++ b/RockLib.Diagnostics.ConfigTests/netcoreapp2.0/RockLib.Diagnostics.ConfigTests.netcoreapp2.0.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <AssemblyName>RockLib.Diagnostics.ConfigTests</AssemblyName>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -15,6 +14,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <Import Project="..\RockLib.Diagnostics.ConfigTests.projitems" Label="Shared" />

--- a/RockLib.Diagnostics.ConfigTests/netcoreapp2.0/RockLib.Diagnostics.ConfigTests.netcoreapp2.0.csproj
+++ b/RockLib.Diagnostics.ConfigTests/netcoreapp2.0/RockLib.Diagnostics.ConfigTests.netcoreapp2.0.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <AssemblyName>RockLib.Diagnostics.ConfigTests</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\RockLib.Diagnostics.ConfigTests.projitems" Label="Shared" />
+
+</Project>

--- a/RockLib.Diagnostics.ConfigTests/netcoreapp2.0/appsettings.json
+++ b/RockLib.Diagnostics.ConfigTests/netcoreapp2.0/appsettings.json
@@ -10,7 +10,7 @@
                     "logFileName": "test_listener1.log"
                 },
                 {
-                    "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests",
+                    "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.netcoreapp2.0",
                     "value": {
                         "name": "test_listener2",
                         "foo": "bar"
@@ -31,7 +31,7 @@
                         "logFileName": "test_listener3.log"
                     },
                     {
-                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests",
+                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.netcoreapp2.0",
                         "value": {
                             "name": "test_listener4",
                             "foo": "baz"
@@ -51,7 +51,7 @@
                         "LogFileName": "test_listener5.log"
                     },
                     {
-                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests",
+                        "type": "CustomTraceListener, RockLib.Diagnostics.ConfigTests.netcoreapp2.0",
                         "value": {
                             "name": "test_listener6",
                             "foo": "qux"

--- a/RockLib.Diagnostics.UnitTests/ConfigurationExtensions/CreateDiagnosticsSettingsTests.cs
+++ b/RockLib.Diagnostics.UnitTests/ConfigurationExtensions/CreateDiagnosticsSettingsTests.cs
@@ -4,6 +4,9 @@ using RockLib.Diagnostics;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Xunit;
+#if NETCOREAPP1_1
+using DefaultTraceListener = RockLib.Diagnostics.DefaultTraceListener;
+#endif
 
 public class TheCreateDiagnosticsSettingsExtensionMethod
 {
@@ -14,7 +17,7 @@ public class TheCreateDiagnosticsSettingsExtensionMethod
             .AddInMemoryCollection(new Dictionary<string, string>
             {
                 { "trace:autoFlush", "true" },
-                { "trace:listeners:type", "System.Diagnostics.DefaultTraceListener, System.Diagnostics.TraceSource" },
+                { "trace:listeners:type", typeof(DefaultTraceListener).AssemblyQualifiedName },
                 { "trace:listeners:value:name", "listener1" },
                 { "trace:listeners:value:logFileName", "listener1.log" },
                 { "trace:listeners:value:filter:type", "System.Diagnostics.EventTypeFilter, System.Diagnostics.TraceSource" },
@@ -22,7 +25,7 @@ public class TheCreateDiagnosticsSettingsExtensionMethod
                 { "sources:name", "source1" },
                 { "sources:switch:name", "sourceSwitch1" },
                 { "sources:switch:level", "Error" },
-                { "sources:listeners:type", "System.Diagnostics.DefaultTraceListener, System.Diagnostics.TraceSource" },
+                { "sources:listeners:type", typeof(DefaultTraceListener).AssemblyQualifiedName },
                 { "sources:listeners:value:name", "listener2" },
                 { "sources:listeners:value:logFileName", "listener2.log" },
                 { "sources:listeners:value:filter:type", "System.Diagnostics.EventTypeFilter, System.Diagnostics.TraceSource" },
@@ -65,7 +68,7 @@ public class TheCreateDiagnosticsSettingsExtensionMethod
             .AddInMemoryCollection(new Dictionary<string, string>
             {
                 { "trace:autoFlush", "true" },
-                { "trace:listeners:type", "System.Diagnostics.DefaultTraceListener, System.Diagnostics.TraceSource" },
+                { "trace:listeners:type", typeof(DefaultTraceListener).AssemblyQualifiedName },
                 { "trace:listeners:name", "listener1" },
                 { "trace:listeners:logFileName", "listener1.log" },
                 { "trace:listeners:filter:type", "System.Diagnostics.EventTypeFilter, System.Diagnostics.TraceSource" },
@@ -115,14 +118,14 @@ public class TheCreateDiagnosticsSettingsExtensionMethod
             .AddInMemoryCollection(new Dictionary<string, string>
             {
                 { "trace:autoFlush", "true" },
-                { "trace:listeners:type", "System.Diagnostics.DefaultTraceListener, System.Diagnostics.TraceSource" },
+                { "trace:listeners:type", typeof(DefaultTraceListener).AssemblyQualifiedName },
                 { "trace:listeners:value:name", "listener1" },
                 { "trace:listeners:value:logFileName", "listener1.log" },
                 { "trace:listeners:value:filter:level", "Warning" },
                 { "sources:name", "source1" },
                 { "sources:switch:name", "sourceSwitch1" },
                 { "sources:switch:level", "Error" },
-                { "sources:listeners:type", "System.Diagnostics.DefaultTraceListener, System.Diagnostics.TraceSource" },
+                { "sources:listeners:type", typeof(DefaultTraceListener).AssemblyQualifiedName },
                 { "sources:listeners:value:name", "listener2" },
                 { "sources:listeners:value:logFileName", "listener2.log" },
                 { "sources:listeners:value:filter:level", "Critical" },

--- a/RockLib.Diagnostics.UnitTests/RockLib.Diagnostics.UnitTests.projitems
+++ b/RockLib.Diagnostics.UnitTests/RockLib.Diagnostics.UnitTests.projitems
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>3ff67f13-c58e-4511-af51-8d02aa779112</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>RockLib.Diagnostics.UnitTests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ConfigurationExtensions\CreateDiagnosticsSettingsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\ConfigureTraceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\GetTraceSourceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\SettingsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\TestInitialization.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tracing\TracingTestSettings.cs" />
+  </ItemGroup>
+</Project>

--- a/RockLib.Diagnostics.UnitTests/RockLib.Diagnostics.UnitTests.shproj
+++ b/RockLib.Diagnostics.UnitTests/RockLib.Diagnostics.UnitTests.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>3ff67f13-c58e-4511-af51-8d02aa779112</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="RockLib.Diagnostics.UnitTests.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/RockLib.Diagnostics.UnitTests/Tracing/TracingTestSettings.cs
+++ b/RockLib.Diagnostics.UnitTests/Tracing/TracingTestSettings.cs
@@ -2,6 +2,9 @@
 using RockLib.Diagnostics;
 using System.Collections.Generic;
 using System.Diagnostics;
+#if NETCOREAPP1_1
+using DefaultTraceListener=RockLib.Diagnostics.DefaultTraceListener;
+#endif
 
 internal static class TracingTestSettings
 {

--- a/RockLib.Diagnostics.UnitTests/net462/RockLib.Diagnostics.UnitTests.net462.csproj
+++ b/RockLib.Diagnostics.UnitTests/net462/RockLib.Diagnostics.UnitTests.net462.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\RockLib.Diagnostics.UnitTests.projitems" Label="Shared" />
+
+</Project>

--- a/RockLib.Diagnostics.UnitTests/netcoreapp1.1/RockLib.Diagnostics.UnitTests.netcoreapp1.1.csproj
+++ b/RockLib.Diagnostics.UnitTests/netcoreapp1.1/RockLib.Diagnostics.UnitTests.netcoreapp1.1.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\RockLib.Diagnostics.UnitTests.projitems" Label="Shared" />
+
+  <PropertyGroup>
+    <DefineConstants>NETCOREAPP1_1</DefineConstants>
+  </PropertyGroup>
+
+</Project>

--- a/RockLib.Diagnostics.UnitTests/netcoreapp2.0/RockLib.Diagnostics.UnitTests.netcoreapp2.0.csproj
+++ b/RockLib.Diagnostics.UnitTests/netcoreapp2.0/RockLib.Diagnostics.UnitTests.netcoreapp2.0.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\RockLib.Diagnostics\RockLib.Diagnostics.csproj" />
+  </ItemGroup>
+
+  <Import Project="..\RockLib.Diagnostics.UnitTests.projitems" Label="Shared" />
+
+</Project>

--- a/RockLib.Diagnostics.sln
+++ b/RockLib.Diagnostics.sln
@@ -5,11 +5,27 @@ VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics", "RockLib.Diagnostics\RockLib.Diagnostics.csproj", "{69B6A78E-8734-4C10-AEEA-FCC5C5E45CFE}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.ConfigTests", "RockLib.Diagnostics.ConfigTests\RockLib.Diagnostics.ConfigTests.csproj", "{33002261-2E90-4158-A870-7635EBC17C44}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.UnitTests.netcoreapp2.0", "RockLib.Diagnostics.UnitTests\netcoreapp2.0\RockLib.Diagnostics.UnitTests.netcoreapp2.0.csproj", "{DE66FC2C-CAC9-42E2-B855-63B101EA9B81}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.UnitTests", "RockLib.Diagnostics.UnitTests\RockLib.Diagnostics.UnitTests.csproj", "{6C9AA8DF-0D36-464E-9042-43B6B1672B48}"
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RockLib.Diagnostics.UnitTests", "RockLib.Diagnostics.UnitTests\RockLib.Diagnostics.UnitTests.shproj", "{3FF67F13-C58E-4511-AF51-8D02AA779112}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.UnitTests.net462", "RockLib.Diagnostics.UnitTests\net462\RockLib.Diagnostics.UnitTests.net462.csproj", "{8AA76477-3CFE-4200-9C62-705F80E535AB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.UnitTests.netcoreapp1.1", "RockLib.Diagnostics.UnitTests\netcoreapp1.1\RockLib.Diagnostics.UnitTests.netcoreapp1.1.csproj", "{7AD829F6-B473-41B7-8EA9-7F7D6EB3E928}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "RockLib.Diagnostics.ConfigTests", "RockLib.Diagnostics.ConfigTests\RockLib.Diagnostics.ConfigTests.shproj", "{7197572B-9CAA-4F88-BFDD-C616BCDF4C5A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.ConfigTests.net462", "RockLib.Diagnostics.ConfigTests\net462\RockLib.Diagnostics.ConfigTests.net462.csproj", "{C10720E1-9402-4D35-9DB3-0D877AD8D0F9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.ConfigTests.netcoreapp1.1", "RockLib.Diagnostics.ConfigTests\netcoreapp1.1\RockLib.Diagnostics.ConfigTests.netcoreapp1.1.csproj", "{20CFCAFC-3EA4-43CC-97BC-B71435E3D186}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RockLib.Diagnostics.ConfigTests.netcoreapp2.0", "RockLib.Diagnostics.ConfigTests\netcoreapp2.0\RockLib.Diagnostics.ConfigTests.netcoreapp2.0.csproj", "{92266BE7-7773-4E2B-9B9A-8D814725E62C}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		RockLib.Diagnostics.UnitTests\RockLib.Diagnostics.UnitTests.projitems*{3ff67f13-c58e-4511-af51-8d02aa779112}*SharedItemsImports = 13
+		RockLib.Diagnostics.ConfigTests\RockLib.Diagnostics.ConfigTests.projitems*{7197572b-9caa-4f88-bfdd-c616bcdf4c5a}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -19,14 +35,30 @@ Global
 		{69B6A78E-8734-4C10-AEEA-FCC5C5E45CFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69B6A78E-8734-4C10-AEEA-FCC5C5E45CFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69B6A78E-8734-4C10-AEEA-FCC5C5E45CFE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{33002261-2E90-4158-A870-7635EBC17C44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{33002261-2E90-4158-A870-7635EBC17C44}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{33002261-2E90-4158-A870-7635EBC17C44}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{33002261-2E90-4158-A870-7635EBC17C44}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6C9AA8DF-0D36-464E-9042-43B6B1672B48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C9AA8DF-0D36-464E-9042-43B6B1672B48}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C9AA8DF-0D36-464E-9042-43B6B1672B48}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C9AA8DF-0D36-464E-9042-43B6B1672B48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE66FC2C-CAC9-42E2-B855-63B101EA9B81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE66FC2C-CAC9-42E2-B855-63B101EA9B81}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE66FC2C-CAC9-42E2-B855-63B101EA9B81}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE66FC2C-CAC9-42E2-B855-63B101EA9B81}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8AA76477-3CFE-4200-9C62-705F80E535AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8AA76477-3CFE-4200-9C62-705F80E535AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8AA76477-3CFE-4200-9C62-705F80E535AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8AA76477-3CFE-4200-9C62-705F80E535AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AD829F6-B473-41B7-8EA9-7F7D6EB3E928}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AD829F6-B473-41B7-8EA9-7F7D6EB3E928}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AD829F6-B473-41B7-8EA9-7F7D6EB3E928}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AD829F6-B473-41B7-8EA9-7F7D6EB3E928}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C10720E1-9402-4D35-9DB3-0D877AD8D0F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C10720E1-9402-4D35-9DB3-0D877AD8D0F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C10720E1-9402-4D35-9DB3-0D877AD8D0F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C10720E1-9402-4D35-9DB3-0D877AD8D0F9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20CFCAFC-3EA4-43CC-97BC-B71435E3D186}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20CFCAFC-3EA4-43CC-97BC-B71435E3D186}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20CFCAFC-3EA4-43CC-97BC-B71435E3D186}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20CFCAFC-3EA4-43CC-97BC-B71435E3D186}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92266BE7-7773-4E2B-9B9A-8D814725E62C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92266BE7-7773-4E2B-9B9A-8D814725E62C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92266BE7-7773-4E2B-9B9A-8D814725E62C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92266BE7-7773-4E2B-9B9A-8D814725E62C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RockLib.Diagnostics/DefaultTraceListener.cs
+++ b/RockLib.Diagnostics/DefaultTraceListener.cs
@@ -38,21 +38,24 @@ namespace RockLib.Diagnostics
         {
             if (NeedIndent)
                 WriteIndent();
-            try
+
+            if (!string.IsNullOrWhiteSpace(LogFileName))
             {
-                using (var stream = new FileInfo(LogFileName).Open(FileMode.OpenOrCreate))
-                using (var streamWriter = new StreamWriter(stream))
+                try
                 {
-                    stream.Position = stream.Length;
-                    if (useWriteLine)
-                        streamWriter.WriteLine(message);
-                    else
-                        streamWriter.Write(message);
+                    using (var stream = new FileInfo(LogFileName).Open(FileMode.OpenOrCreate))
+                    using (var streamWriter = new StreamWriter(stream))
+                    {
+                        stream.Position = stream.Length;
+                        if (useWriteLine)
+                            streamWriter.WriteLine(message);
+                        else
+                            streamWriter.Write(message);
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"An exception occurred writing trace output to log file '{LogFileName}'. {ex}");
+                catch
+                {
+                }
             }
         }
     }

--- a/RockLib.Diagnostics/DefaultTraceListener.cs
+++ b/RockLib.Diagnostics/DefaultTraceListener.cs
@@ -1,0 +1,60 @@
+﻿#if NETSTANDARD1_6
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace RockLib.Diagnostics
+{
+    /// <summary>
+    /// Provides the default output methods and behavior for tracing.
+    /// </summary>
+    /// <remarks>
+    /// This class is defined for .NET Standard 1.6 only because its
+    /// <see cref="System.Diagnostics.DefaultTraceListener"/> implementation doesn't actually
+    /// do anything - it is just an empty stub. Other targets define a fully functional implementation
+    /// of <see cref="System.Diagnostics.DefaultTraceListener"/>
+    /// </remarks>
+    public class DefaultTraceListener : TraceListener
+    {
+        /// <summary>
+        /// Gets or sets the name of a log file to write trace or debug messages to.
+        /// </summary>
+        public string LogFileName { get; set; }
+
+        /// <inheritdoc />
+        public override void Write(string message)
+        {
+            Write(message, false);
+        }
+
+        /// <inheritdoc />
+        public override void WriteLine(string message)
+        {
+            Write(message, true);
+            NeedIndent = true;
+        }
+
+        private void Write(string message, bool useWriteLine)
+        {
+            if (NeedIndent)
+                WriteIndent();
+            try
+            {
+                using (var stream = new FileInfo(LogFileName).Open(FileMode.OpenOrCreate))
+                using (var streamWriter = new StreamWriter(stream))
+                {
+                    stream.Position = stream.Length;
+                    if (useWriteLine)
+                        streamWriter.WriteLine(message);
+                    else
+                        streamWriter.Write(message);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"An exception occurred writing trace output to log file '{LogFileName}'. {ex}");
+            }
+        }
+    }
+}
+#endif

--- a/RockLib.Diagnostics/RockLib.Diagnostics.csproj
+++ b/RockLib.Diagnostics/RockLib.Diagnostics.csproj
@@ -21,6 +21,10 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\RockLib.Diagnostics.xml</DocumentationFile>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <DefineConstants>NETSTANDARD1_6</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="RockLib.Configuration" Version="2.0.0" />
     <PackageReference Include="RockLib.Configuration.ObjectFactory" Version="1.1.1" />


### PR DESCRIPTION
The `System.Diagnostics.DefaultTraceListener` class from the `System.Diagnostics.TraceSource` package that targets .NET Standard 1.1 *doesn't actually do anything* - it's just a placeholder with no behavior. This pull request adds a `RockLib.Diagnostics.DefaultTraceListener` class for .NET Standard 1.1 *only*. It behaves just like the `System.Diagnostics.DefaultTraceListener` from .NET Framework and .NET Core 2.0. This class is also used as the default type of `System.Diagnostics.TraceListener` in the `CreateDiagnosticsSettings` extension method.