### PR TITLE
Fix bug in DebugTraceListener

### DIFF
--- a/RockLib.Diagnostics/CHANGELOG.md
+++ b/RockLib.Diagnostics/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adds SourceLink to nuget package.
 
+#### Fixed
+
+- Fixes bug in DebugTraceListener where nothing was ever actually written to debug.
+
 ----
 
 **Note:** Release notes in the above format are not available for earlier versions of

--- a/RockLib.Diagnostics/DebugTraceListener.cs
+++ b/RockLib.Diagnostics/DebugTraceListener.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿#define DEBUG
+using System.Diagnostics;
 
 namespace RockLib.Diagnostics
 {


### PR DESCRIPTION
Nothing was ever actually written to debug because the write methods in the System.Diagnostics.Debug class are all decorated with the `[Conditional("DEBUG")]` attribute. Without defining the `DEBUG` symbol in the DebugTraceListener.cs file, the compiler was removing the method calls when compiling as Release.