### PR TITLE
Removed .NET 6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,17 +3,17 @@
 		<EnableNETAnalyzers>true</EnableNETAnalyzers>
 	</PropertyGroup>
 	<PropertyGroup>
-		<AnalysisMode>AllEnabledByDefault</AnalysisMode>
+		<AnalysisMode>All</AnalysisMode>
 		<Authors>Rocket Mortgage</Authors>
-		<Copyright>Copyright 2024 (c) Rocket Mortgage. All rights reserved.</Copyright>
+		<Copyright>Copyright 2025 (c) Rocket Mortgage. All rights reserved.</Copyright>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<TargetFrameworks>net6.0;net48;net8.0</TargetFrameworks>
+		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<NoWarn>NU1603,NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
-		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Makes configuring tracing easy and standardized for .NET Core, .NET Standard, and .NET Framework.
 
+> Note: The 4.0.0 release of this library will be the final version with upgrades and changes. Bug fixes will continue to be released as needed.
+
 ## Installation
 
 ```powershell

--- a/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.csproj
+++ b/RockLib.Diagnostics.ConfigTests/RockLib.Diagnostics.ConfigTests.csproj
@@ -12,9 +12,9 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.Diagnostics.Tests/RockLib.Diagnostics.Tests.csproj
+++ b/RockLib.Diagnostics.Tests/RockLib.Diagnostics.Tests.csproj
@@ -4,11 +4,11 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="6.12.1" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="RockLib.UniversalMemberAccessor" Version="2.0.0" />
-		<PackageReference Include="xunit" Version="2.9.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/RockLib.Diagnostics/CHANGELOG.md
+++ b/RockLib.Diagnostics/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 4.0.0-alpha.1 - 2025-01-22
+## 4.0.0 - 2025-01-24
 
 ### Changed
 * Removed .NET 6 as a target framework

--- a/RockLib.Diagnostics/CHANGELOG.md
+++ b/RockLib.Diagnostics/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.0-alpha.1 - 2025-01-22
+
+### Changed
+* Removed .NET 6 as a target framework
+
 ## 3.0.2 - 2024-10-17
 
 ### Changed

--- a/RockLib.Diagnostics/RockLib.Diagnostics.csproj
+++ b/RockLib.Diagnostics/RockLib.Diagnostics.csproj
@@ -11,9 +11,9 @@
 		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 		<PackageReleaseNotes>A changelog is available at https://github.com/RockLib/RockLib.Diagnostics/blob/main/RockLib.Diagnostics/CHANGELOG.md.</PackageReleaseNotes>
 		<PackageTags>RockLib Trace TraceSource Configuration</PackageTags>
-		<PackageVersion>3.0.2</PackageVersion>
+		<PackageVersion>4.0.0</PackageVersion>
 		<PublishRepositoryUrl>True</PublishRepositoryUrl>
-		<Version>3.0.2</Version>
+		<Version>4.0.0</Version>
 	</PropertyGroup>
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(PackageId).xml</DocumentationFile>

--- a/RockLib.Diagnostics/RockLib.Diagnostics.csproj
+++ b/RockLib.Diagnostics/RockLib.Diagnostics.csproj
@@ -26,7 +26,6 @@
 		<None Include="..\icon.png" Pack="true" PackagePath="" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="RockLib.Configuration" Version="4.0.3" />
 		<PackageReference Include="RockLib.Configuration.ObjectFactory" Version="3.0.0" />
 	</ItemGroup>


### PR DESCRIPTION
## Description

This removes .NET 6, and adds a note that this release will be the last one.

## Type of change:

4. Breaking change (fix or feature that could cause existing functionality to not work as expected)
